### PR TITLE
Fix: stacktrace not shown in kibana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 4.2.3 - 2022-03-23
+
+### Fixed
+
+ - Fix stacktrace not showing in kibana
+
 ## 4.2.2 - 2021-04-01
 
 ### Fixed

--- a/sap/cf_logging/__init__.py
+++ b/sap/cf_logging/__init__.py
@@ -10,7 +10,7 @@ from sap.cf_logging.job_logging.framework import JobFramework
 from sap.cf_logging.record.request_log_record import RequestWebRecord
 from sap.cf_logging.record.simple_log_record import SimpleLogRecord
 
-__version__ = '4.2.2'
+__version__ = '4.2.3'
 
 _SETUP_DONE = False
 FRAMEWORK = None

--- a/sap/cf_logging/record/simple_log_record.py
+++ b/sap/cf_logging/record/simple_log_record.py
@@ -77,7 +77,11 @@ class SimpleLogRecord(logging.LogRecord):
 
         if self.levelno == logging.ERROR and self.exc_info:
             stacktrace = ''.join(traceback.format_exception(*self.exc_info))
-            record['stacktrace'] = format_stacktrace(stacktrace).split('\n')
+            stacktrace = format_stacktrace(stacktrace)
+            record['stacktrace'] = stacktrace.split('\n')
+            record['msg'] += "\n"
+            record['msg'] += stacktrace
+
 
         record.update(self.extra)
         if len(self.custom_fields) > 0:

--- a/tests/unit/formatters/test_json_formatter.py
+++ b/tests/unit/formatters/test_json_formatter.py
@@ -27,3 +27,26 @@ def test_non_json_serializable():
     record_object = json.loads(FORMATTER.format(log_record))
     assert record_object.get('cls') is not None
     assert 'MyClass' in record_object.get('cls')
+
+def test_stacktrace_is_added_to_msg_field():
+    """
+    Tests that JSONFormatter adds stracktrace to msg field. The stacktrace field
+    is no longer rendered in Kibana, see https://github.com/SAP/cf-python-logging-support/issues/45
+    for related report.
+    """
+    # Generate exception for the test
+    try:
+        raise ValueError("Dummy Exception")
+    except ValueError as e:
+        exc_info = (type(e), e, e.__traceback__)
+
+    framework = JobFramework()
+    extra = {}
+
+    log_record = SimpleLogRecord(extra, framework, 'name', logging.ERROR, FILE, LINE, 'Error found!', [], exc_info)
+    record_object = json.loads(FORMATTER.format(log_record))
+    assert "Dummy Exception" in "".join(record_object["stacktrace"])
+    expected_msg = "Error found!"
+    expected_msg += "\n"
+    expected_msg += "\n".join(record_object["stacktrace"])
+    assert record_object["msg"] == expected_msg


### PR DESCRIPTION
When logging exceptions with logging.exception(), the cf-python-logging library will emit the stacktrace as a separate field in the JSON. This field is now being filtered by the BTP and no longer visible in Kibana.

This commit adds the stacktrace to the main 'msg' field and thus makes it possible again to debug exceptions in our Python applications.